### PR TITLE
Chain API calls on sign-in success

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 tmp
 dist
 vendor.js

--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -1,8 +1,11 @@
 'use strict'
 
 const api = require('./api')
+const cartApi = require('../carts/api')
+const productApi = require('../products/api')
 const getFormFields = require('../../../lib/get-form-fields')
 const ui = require('./ui')
+const cartParse = require('../carts/cartParse')
 
 const onSignUp = function (event) {
   event.preventDefault()
@@ -19,6 +22,10 @@ const onSignIn = function (event) {
   const data = getFormFields(this)
   api.signIn(data)
     .then(ui.signInSuccess)
+    .then(productApi.getProducts)
+    .then(cartParse.setAllProducts)
+    .then(cartApi.getCarts)
+    .then(cartParse.setAllLocalCarts)
     .catch(ui.signInFailure)
 }
 

--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -20,8 +20,9 @@ const signInSuccess = function (data) {
   console.log('Sign In Success')
 }
 
-const signInFailure = function () {
+const signInFailure = function (error) {
   $('#sign-in').get(0).reset()
+  console.error(error)
   console.log('Sign In Error')
 }
 


### PR DESCRIPTION
- Add getProducts, setProducts, getCarts, and setAllCarts on sign-in
- Tested: All good!
- Things to consider: logging specific error messages for testing based
  on which part of the chain fails
-.gitignore edited to ignore .env file  in consideration for Stripe integration

Ian, Andrew