### PR TITLE
Stripe script bug

### DIFF
--- a/assets/scripts/checkouts/events.js
+++ b/assets/scripts/checkouts/events.js
@@ -2,6 +2,7 @@
 /* global StripeCheckout */
 
 const checkoutApi = require('./api')
+const $script = require('scriptjs')
 // const checkoutUi = require('./ui.js')
 // const getFormFields = require('../../../lib/get-form-fields')
 
@@ -14,6 +15,7 @@ const checkoutApi = require('./api')
 // Stripe's API.
 // Also adds an event listener to the submit-purchase-stripe button, so that when
 // clicked, opens the stripe modal for checkout
+
 const checkout = function () {
   const handler = StripeCheckout.configure({
     key: 'pk_test_AFBOWpYyewj4wYgQD8iUWg2i',
@@ -40,6 +42,7 @@ const checkout = function () {
         })
     }
   })
+
   // adds an event listener to the submit-purchase-stripe button, so that when
   // clicked, opens the stripe modal for checkout
   document.getElementById('submit-purchase-stripe').addEventListener('click', function (event) {
@@ -61,6 +64,12 @@ const checkout = function () {
   })
 }
 
+$script('https://checkout.stripe.com/checkout.js', checkout)
+
+// This handler connects this whole file to index.js file. This allows the above functions to run
+const checkoutHandlers = () => {
+}
+
 module.exports = {
-  checkout
+  checkoutHandlers
 }

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -9,5 +9,5 @@ $(() => {
   authEvents.addHandlers()
   productEvents.productHandlers()
   cartEvents.addHandlers()
-  checkoutEvents.checkout()
+  checkoutEvents.checkoutHandlers()
 })

--- a/index.html
+++ b/index.html
@@ -10,8 +10,6 @@
       <!-- Do not add `script` tags-->
       <script src="public/vendor.js" type="text/javascript" charset="utf-8" defer></script>
       <script src="public/application.js" type="text/javascript" charset="utf-8" defer></script>
-      <!-- Below script is currently necessary to make Stripe work TODO replace this with $script in JS file -->
-      <script src="https://checkout.stripe.com/checkout.js"></script>
 
     </head>
     <body>


### PR DESCRIPTION
Hey team! I found a work around with the script tag that calls the stripe checkout. 

Initial problem:
We used a script tag on top of our index.html file. According to our template, this is taboo. Initially, we used the script module to call the stripe checkout website, but in our console an error popped up in the console about StripeCheckout not being defined. This was due to the checkout function running before the script module.

Solution:
Instead of invoking the checkout function on page load, I created a purchaseHandler function that is used to be module.exported into the index.js file. This allows the whole purchases/events.js file to be connected to the index.js file, which then allows the script module to run.